### PR TITLE
add conda support for prebuilt images

### DIFF
--- a/mnist/score_component/Dockerfile
+++ b/mnist/score_component/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_TAG=nightly-py3
-FROM tensorflow/tensorflow:$BASE_IMAGE_TAG
+ARG BASE_IMAGE_TAG=latest
+FROM zzn2/tensorflow-with-conda:$BASE_IMAGE_TAG
 RUN pip install --upgrade sklearn
 COPY ./src/ /work_dir/src/

--- a/mnist/train_component/Dockerfile
+++ b/mnist/train_component/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_TAG=nightly-py3
-FROM tensorflow/tensorflow:$BASE_IMAGE_TAG
+ARG BASE_IMAGE_TAG=latest
+FROM zzn2/tensorflow-with-conda:$BASE_IMAGE_TAG
 RUN pip install --upgrade sklearn
 COPY ./src/ /work_dir/src/


### PR DESCRIPTION
Otherwise image build will fail on AML Service.

base image link:
https://github.com/zzn2/tensorflow-with-conda/blob/master/Dockerfile